### PR TITLE
Add credential-registry project with Clarity contract and configuration

### DIFF
--- a/credential-registry/Clarinet.toml
+++ b/credential-registry/Clarinet.toml
@@ -1,0 +1,11 @@
+[project]
+name = "credential-registry"
+description = "On-chain credentials and certificates"
+authors = []
+telemetry = false
+cache_dir = "./.cache"
+requirements = []
+[contracts.credential-registry]
+path = "contracts/credential-registry.clar"
+clarity_version = 2
+epoch = 2.4

--- a/credential-registry/README.md
+++ b/credential-registry/README.md
@@ -1,0 +1,52 @@
+# Credential Registry - On-Chain Credentials and Certificates
+
+Issue, verify, and manage digital credentials on the blockchain.
+
+## Features
+
+- **Issuer Registry**: Register and verify credential issuers
+- **Multiple Types**: Certificates, licenses, badges, degrees
+- **Issue Credentials**: Mint credentials for holders
+- **Revocation**: Revoke compromised or invalid credentials
+- **Verification**: Third-party verification tracking
+- **Expiration**: Optional expiration dates
+- **Transferability**: Transfer credentials to new holders
+
+## Key Functions
+
+### register-issuer
+Register as a credential issuer.
+
+### issue-credential
+Issue a new credential to a holder.
+
+### revoke-credential
+Revoke a previously issued credential.
+
+### verify-credential
+Third-party verification of credentials.
+
+### transfer-credential
+Transfer credential to a new holder.
+
+## Credential Types
+
+- **Certificate**: Completion certificates
+- **License**: Professional licenses
+- **Badge**: Achievement badges
+- **Degree**: Academic degrees
+
+## Use Cases
+
+- Educational certificates
+- Professional licenses
+- Training completion
+- Achievement badges
+- Identity verification
+
+## Deployment
+
+```bash
+clarinet check
+clarinet deploy --testnet
+```

--- a/credential-registry/contracts/credential-registry.clar
+++ b/credential-registry/contracts/credential-registry.clar
@@ -1,0 +1,280 @@
+;; Credential Registry - On-Chain Credentials and Certificates
+;; Issue, verify, and revoke digital credentials
+
+;; Constants
+(define-constant contract-owner tx-sender)
+(define-constant err-owner-only (err u100))
+(define-constant err-not-found (err u101))
+(define-constant err-unauthorized (err u102))
+(define-constant err-already-issued (err u103))
+(define-constant err-revoked (err u104))
+(define-constant err-expired (err u105))
+(define-constant err-not-issuer (err u106))
+
+;; Data Variables
+(define-data-var credential-nonce uint u0)
+
+;; Credential Types
+(define-constant type-certificate u1)
+(define-constant type-license u2)
+(define-constant type-badge u3)
+(define-constant type-degree u4)
+
+;; Status
+(define-constant status-active u1)
+(define-constant status-revoked u2)
+(define-constant status-expired u3)
+
+;; Data Maps
+(define-map issuers
+  { issuer: principal }
+  {
+    name: (string-ascii 64),
+    verified: bool,
+    credentials-issued: uint,
+    reputation: uint,
+    registered-at: uint
+  }
+)
+
+(define-map credentials
+  { credential-id: uint }
+  {
+    holder: principal,
+    issuer: principal,
+    credential-type: uint,
+    title: (string-ascii 128),
+    metadata-uri: (string-ascii 256),
+    issued-at: uint,
+    expires-at: (optional uint),
+    status: uint,
+    verification-count: uint
+  }
+)
+
+(define-map holder-credentials
+  { holder: principal, index: uint }
+  { credential-id: uint }
+)
+
+(define-map holder-credential-count
+  { holder: principal }
+  { count: uint }
+)
+
+(define-map verifications
+  { credential-id: uint, verifier: principal }
+  {
+    verified: bool,
+    verified-at: uint,
+    notes: (optional (string-ascii 256))
+  }
+)
+
+;; Read-Only Functions
+(define-read-only (get-issuer (issuer principal))
+  (map-get? issuers { issuer: issuer })
+)
+
+(define-read-only (is-verified-issuer (issuer principal))
+  (match (get-issuer issuer)
+    info (get verified info)
+    false
+  )
+)
+
+(define-read-only (get-credential (credential-id uint))
+  (map-get? credentials { credential-id: credential-id })
+)
+
+(define-read-only (is-credential-valid (credential-id uint))
+  (match (get-credential credential-id)
+    cred
+      (and
+        (is-eq (get status cred) status-active)
+        (match (get expires-at cred)
+          expiry (<= block-height expiry)
+          true
+        )
+      )
+    false
+  )
+)
+
+(define-read-only (get-holder-credential-count (holder principal))
+  (default-to
+    { count: u0 }
+    (map-get? holder-credential-count { holder: holder })
+  )
+)
+
+(define-read-only (get-holder-credential-id (holder principal) (index uint))
+  (map-get? holder-credentials { holder: holder, index: index })
+)
+
+(define-read-only (get-verification (credential-id uint) (verifier principal))
+  (map-get? verifications { credential-id: credential-id, verifier: verifier })
+)
+
+;; Public Functions
+(define-public (register-issuer (name (string-ascii 64)))
+  (begin
+    (map-set issuers
+      { issuer: tx-sender }
+      {
+        name: name,
+        verified: false,
+        credentials-issued: u0,
+        reputation: u0,
+        registered-at: block-height
+      }
+    )
+    
+    (ok true)
+  )
+)
+
+(define-public (verify-issuer (issuer principal))
+  (let (
+    (issuer-info (unwrap! (get-issuer issuer) err-not-found))
+  )
+    (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+    
+    (map-set issuers
+      { issuer: issuer }
+      (merge issuer-info { verified: true })
+    )
+    
+    (ok true)
+  )
+)
+
+(define-public (issue-credential
+    (holder principal)
+    (credential-type uint)
+    (title (string-ascii 128))
+    (metadata-uri (string-ascii 256))
+    (expires-at (optional uint))
+  )
+  (let (
+    (credential-id (+ (var-get credential-nonce) u1))
+    (issuer-info (unwrap! (get-issuer tx-sender) err-not-issuer))
+    (holder-count (get-holder-credential-count holder))
+  )
+    (map-set credentials
+      { credential-id: credential-id }
+      {
+        holder: holder,
+        issuer: tx-sender,
+        credential-type: credential-type,
+        title: title,
+        metadata-uri: metadata-uri,
+        issued-at: block-height,
+        expires-at: expires-at,
+        status: status-active,
+        verification-count: u0
+      }
+    )
+    
+    (map-set holder-credentials
+      { holder: holder, index: (get count holder-count) }
+      { credential-id: credential-id }
+    )
+    
+    (map-set holder-credential-count
+      { holder: holder }
+      { count: (+ (get count holder-count) u1) }
+    )
+    
+    (map-set issuers
+      { issuer: tx-sender }
+      (merge issuer-info {
+        credentials-issued: (+ (get credentials-issued issuer-info) u1)
+      })
+    )
+    
+    (var-set credential-nonce credential-id)
+    (ok credential-id)
+  )
+)
+
+(define-public (revoke-credential (credential-id uint))
+  (let (
+    (cred (unwrap! (get-credential credential-id) err-not-found))
+  )
+    (asserts! (is-eq tx-sender (get issuer cred)) err-unauthorized)
+    (asserts! (is-eq (get status cred) status-active) err-revoked)
+    
+    (map-set credentials
+      { credential-id: credential-id }
+      (merge cred { status: status-revoked })
+    )
+    
+    (ok true)
+  )
+)
+
+(define-public (verify-credential (credential-id uint) (notes (optional (string-ascii 256))))
+  (let (
+    (cred (unwrap! (get-credential credential-id) err-not-found))
+  )
+    (asserts! (is-credential-valid credential-id) err-revoked)
+    
+    (map-set verifications
+      { credential-id: credential-id, verifier: tx-sender }
+      {
+        verified: true,
+        verified-at: block-height,
+        notes: notes
+      }
+    )
+    
+    (map-set credentials
+      { credential-id: credential-id }
+      (merge cred {
+        verification-count: (+ (get verification-count cred) u1)
+      })
+    )
+    
+    (ok true)
+  )
+)
+
+(define-public (transfer-credential (credential-id uint) (new-holder principal))
+  (let (
+    (cred (unwrap! (get-credential credential-id) err-not-found))
+  )
+    (asserts! (is-eq tx-sender (get holder cred)) err-unauthorized)
+    (asserts! (is-credential-valid credential-id) err-revoked)
+    
+    (map-set credentials
+      { credential-id: credential-id }
+      (merge cred { holder: new-holder })
+    )
+    
+    (ok true)
+  )
+)
+
+(define-public (update-issuer-reputation (issuer principal) (reputation-delta int))
+  (let (
+    (issuer-info (unwrap! (get-issuer issuer) err-not-found))
+    (current-rep (get reputation issuer-info))
+    (new-rep (if (< reputation-delta 0)
+      (if (> (to-uint (- reputation-delta)) current-rep)
+        u0
+        (- current-rep (to-uint (- reputation-delta)))
+      )
+      (+ current-rep (to-uint reputation-delta))
+    ))
+  )
+    (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+    
+    (map-set issuers
+      { issuer: issuer }
+      (merge issuer-info { reputation: new-rep })
+    )
+    
+    (ok new-rep)
+  )
+)

--- a/credential-registry/deployments/default.testnet-plan.yaml
+++ b/credential-registry/deployments/default.testnet-plan.yaml
@@ -1,0 +1,18 @@
+---
+id: 0
+name: Testnet deployment
+network: testnet
+stacks-node: "https://api.testnet.hiro.so"
+bitcoin-node: "http://blockstack:blockstacksystem@bitcoind.testnet.stacks.co:18332"
+plan:
+  batches:
+    - id: 0
+      transactions:
+        - contract-publish:
+            contract-name: credential-registry
+            expected-sender: ST3P3DPDB69YP0Z259SS6MSA16GBQEBF8KG8P96D2
+            cost: 24648716
+            path: contracts/credential-registry.clar
+            anchor-block-only: true
+            clarity-version: 2
+      epoch: "2.4"

--- a/credential-registry/settings/Devnet.toml
+++ b/credential-registry/settings/Devnet.toml
@@ -1,0 +1,157 @@
+[network]
+name = "devnet"
+deployment_fee_rate = 10
+
+[accounts.deployer]
+mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
+balance = 100_000_000_000_000
+sbtc_balance = 1_000_000_000
+# secret_key: 753b7cc01a1a2e86221266a154af739463fce51219d97e4f856cd7200c3bd2a601
+# stx_address: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+# btc_address: mqVnk6NPRdhntvfm4hh9vvjiRkFDUuSYsH
+
+[accounts.wallet_1]
+mnemonic = "sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild"
+balance = 100_000_000_000_000
+sbtc_balance = 1_000_000_000
+# secret_key: 7287ba251d44a4d3fd9276c88ce34c5c52a038955511cccaf77e61068649c17801
+# stx_address: ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5
+# btc_address: mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC
+
+[accounts.wallet_2]
+mnemonic = "hold excess usual excess ring elephant install account glad dry fragile donkey gaze humble truck breeze nation gasp vacuum limb head keep delay hospital"
+balance = 100_000_000_000_000
+sbtc_balance = 1_000_000_000
+# secret_key: 530d9f61984c888536871c6573073bdfc0058896dc1adfe9a6a10dfacadc209101
+# stx_address: ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG
+# btc_address: muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG
+
+[accounts.wallet_3]
+mnemonic = "cycle puppy glare enroll cost improve round trend wrist mushroom scorpion tower claim oppose clever elephant dinosaur eight problem before frozen dune wagon high"
+balance = 100_000_000_000_000
+sbtc_balance = 1_000_000_000
+# secret_key: d655b2523bcd65e34889725c73064feb17ceb796831c0e111ba1a552b0f31b3901
+# stx_address: ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC
+# btc_address: mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7
+
+[accounts.wallet_4]
+mnemonic = "board list obtain sugar hour worth raven scout denial thunder horse logic fury scorpion fold genuine phrase wealth news aim below celery when cabin"
+balance = 100_000_000_000_000
+sbtc_balance = 1_000_000_000
+# secret_key: f9d7206a47f14d2870c163ebab4bf3e70d18f5d14ce1031f3902fbbc894fe4c701
+# stx_address: ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND
+# btc_address: mg1C76bNTutiCDV3t9nWhZs3Dc8LzUufj8
+
+[accounts.wallet_5]
+mnemonic = "hurry aunt blame peanut heavy update captain human rice crime juice adult scale device promote vast project quiz unit note reform update climb purchase"
+balance = 100_000_000_000_000
+sbtc_balance = 1_000_000_000
+# secret_key: 3eccc5dac8056590432db6a35d52b9896876a3d5cbdea53b72400bc9c2099fe801
+# stx_address: ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB
+# btc_address: mweN5WVqadScHdA81aATSdcVr4B6dNokqx
+
+[accounts.wallet_6]
+mnemonic = "area desk dutch sign gold cricket dawn toward giggle vibrant indoor bench warfare wagon number tiny universe sand talk dilemma pottery bone trap buddy"
+balance = 100_000_000_000_000
+sbtc_balance = 1_000_000_000
+# secret_key: 7036b29cb5e235e5fd9b09ae3e8eec4404e44906814d5d01cbca968a60ed4bfb01
+# stx_address: ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0
+# btc_address: mzxXgV6e4BZSsz8zVHm3TmqbECt7mbuErt
+
+[accounts.wallet_7]
+mnemonic = "prevent gallery kind limb income control noise together echo rival record wedding sense uncover school version force bleak nuclear include danger skirt enact arrow"
+balance = 100_000_000_000_000
+sbtc_balance = 1_000_000_000
+# secret_key: b463f0df6c05d2f156393eee73f8016c5372caa0e9e29a901bb7171d90dc4f1401
+# stx_address: ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ
+# btc_address: n37mwmru2oaVosgfuvzBwgV2ysCQRrLko7
+
+[accounts.wallet_8]
+mnemonic = "female adjust gallery certain visit token during great side clown fitness like hurt clip knife warm bench start reunion globe detail dream depend fortune"
+balance = 100_000_000_000_000
+sbtc_balance = 1_000_000_000
+# secret_key: 6a1a754ba863d7bab14adbbc3f8ebb090af9e871ace621d3e5ab634e1422885e01
+# stx_address: ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP
+# btc_address: n2v875jbJ4RjBnTjgbfikDfnwsDV5iUByw
+
+[accounts.faucet]
+mnemonic = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform"
+balance = 100_000_000_000_000
+sbtc_balance = 1_000_000_000
+# secret_key: de433bdfa14ec43aa1098d5be594c8ffb20a31485ff9de2923b2689471c401b801
+# stx_address: STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6
+# btc_address: mjSrB3wS4xab3kYqFktwBzfTdPg367ZJ2d
+
+[devnet]
+disable_stacks_explorer = false
+disable_stacks_api = false
+# disable_postgres = false
+# disable_bitcoin_explorer = true
+# working_dir = "tmp/devnet"
+# stacks_node_events_observers = ["host.docker.internal:8002"]
+# miner_mnemonic = "fragile loan twenty basic net assault jazz absorb diet talk art shock innocent float punch travel gadget embrace caught blossom hockey surround initial reduce"
+# miner_derivation_path = "m/44'/5757'/0'/0/0"
+# faucet_mnemonic = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform"
+# faucet_derivation_path = "m/44'/5757'/0'/0/0"
+# stacker_mnemonic = "empty lens any direct brother then drop fury rule pole win claim scissors list rescue horn rent inform relief jump sword weekend half legend"
+# stacker_derivation_path = "m/44'/5757'/0'/0/0"
+# orchestrator_port = 20445
+# bitcoin_node_p2p_port = 18444
+# bitcoin_node_rpc_port = 18443
+# bitcoin_node_username = "devnet"
+# bitcoin_node_password = "devnet"
+# bitcoin_controller_block_time = 30_000
+# stacks_node_rpc_port = 20443
+# stacks_node_p2p_port = 20444
+# stacks_api_port = 3999
+# stacks_api_events_port = 3700
+# bitcoin_explorer_port = 8001
+# stacks_explorer_port = 8000
+# postgres_port = 5432
+# postgres_username = "postgres"
+# postgres_password = "postgres"
+# postgres_database = "postgres"
+# bitcoin_node_image_url = "lncm/bitcoind:v27.2"
+# stacks_node_image_url = "blockstack/stacks-blockchain:3.2.0.0.2-alpine"
+# stacks_signer_image_url = "blockstack/stacks-signer:3.2.0.0.2.0-alpine"
+# stacks_api_image_url = "hirosystems/stacks-blockchain-api:latest"
+# stacks_explorer_image_url = "hirosystems/explorer:latest"
+# bitcoin_explorer_image_url = "quay.io/hirosystems/bitcoin-explorer:devnet"
+# postgres_image_url = "postgres:alpine"
+
+# epoch_2_0 = 100
+# epoch_2_05 = 100
+# epoch_2_1 = 101
+# epoch_2_2 = 102
+# epoch_2_3 = 103
+# epoch_2_4 = 104
+# epoch_2_5 = 108
+# epoch_3_0 = 142
+# epoch_3_1 = 144
+# epoch_3_2 = 146
+
+# Send some stacking orders
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 1
+duration = 10
+auto_extend = true
+wallet = "wallet_1"
+slots = 2
+btc_address = "mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 1
+duration = 10
+auto_extend = true
+wallet = "wallet_2"
+slots = 2
+btc_address = "muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 1
+duration = 10
+auto_extend = true
+wallet = "wallet_3"
+slots = 2
+btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"
+

--- a/credential-registry/settings/Testnet.toml
+++ b/credential-registry/settings/Testnet.toml
@@ -1,0 +1,6 @@
+[network]
+name = "testnet"
+
+[accounts.deployer]
+mnemonic = "tube school delay discover broom gallery ahead arena ceiling kid biology spell bachelor section initial wall join public major aisle question hotel maid hurt"
+# stx_address: ST3P3DPDB69YP0Z259SS6MSA16GBQEBF8KG8P96D2


### PR DESCRIPTION
## Overview
This PR adds the `credential-registry` component - a decentralized system for issuing, verifying, and managing digital credentials and certificates on the Stacks blockchain.

## What's Added
- **Clarity smart contract** (`credential-registry.clar`) with credential management capabilities
- Complete project structure with Clarinet configuration
- Comprehensive documentation and README
- Deployment configuration for testnet

## Key Features
📜 **Issuer Registry** - Register and verify credential issuers
🎓 **Multiple Credential Types** - Certificates, licenses, badges, degrees
✅ **Issue Credentials** - Mint credentials for holders with metadata
🚫 **Revocation System** - Revoke compromised or invalid credentials
🔍 **Third-Party Verification** - Track verification by external parties
⏰ **Expiration Support** - Optional expiration dates for time-limited credentials
🔄 **Transferability** - Transfer credentials to new holders

## Credential Types
1. **Certificate (Type 1)** - Completion certificates
2. **License (Type 2)** - Professional licenses
3. **Badge (Type 3)** - Achievement badges
4. **Degree (Type 4)** - Academic degrees

## Credential Status
- **Active (Status 1)** - Valid and usable credential
- **Revoked (Status 2)** - Invalidated credential
- **Expired (Status 3)** - Time-expired credential

## Contract Functions

### Public Functions - Issuer Management
- `register-issuer(name)` - Register as a credential issuer
- `verify-issuer(issuer)` - Verify an issuer (owner only)
- `update-issuer-reputation(issuer, delta)` - Update issuer reputation (owner only)

### Public Functions - Credential Management
- `issue-credential(holder, type, title, metadata-uri, expires-at)` - Issue new credential
- `revoke-credential(credential-id)` - Revoke a credential (issuer only)
- `verify-credential(credential-id, notes)` - Third-party verification
- `transfer-credential(credential-id, new-holder)` - Transfer to new holder

### Read-Only Functions
- `get-issuer(issuer)` - Get issuer information
- `is-verified-issuer(issuer)` - Check if issuer is verified
- `get-credential(credential-id)` - Get credential details
- `is-credential-valid(credential-id)` - Check credential validity
- `get-holder-credential-count(holder)` - Get holder's credential count
